### PR TITLE
Real site identity, landing page & README (closes #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,68 @@
-# Website
+# Санскрит: элементарный курс Бюлера — упражнения
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+Электронное издание упражнений из **«Руководства к элементарному курсу санскритского
+языка»** Г. Бюлера (Стокгольм, 1923), собранное как сайт на
+[Docusaurus](https://docusaurus.io/) и опубликованное на
+[GitHub Pages](https://alexander-myltsev.github.io/buhler-sanskrit-book/).
 
-## Installation
+Каждый урок содержит два упражнения — перевод с санскрита и перевод на санскрит
+(в уроках 43–47 дан только перевод на санскрит). Санскрит показан в деванагари с
+латинской транслитерацией (IAST); грамматические термины размечены, по всему тексту
+работает локальный полнотекстовый поиск.
+
+## Источник
+
+- **Оригинал:** Г. Бюлер, «Руководство к элементарному курсу санскритского языка»,
+  Стокгольм, 1923.
+- **Электронная версия 2.0:** подготовлена **Н. П. Лихушиной**, апрель 2008 г. —
+  исправленные переводы отдельных слов, глагольные корни в ступени *guṇa*, приложенный
+  русско-санскритский словарик. Полный текст благодарностей и предисловия —
+  в [`docs/intro.mdx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/docs/intro.mdx).
+
+## Охват
+
+Оцифровано **20 из 48 уроков** —
+[`docs/lesson1.mdx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/docs/lesson1.mdx) …
+[`docs/lesson20.mdx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/docs/lesson20.mdx)
+плюс [`docs/intro.mdx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/docs/intro.mdx).
+Уроки 21–48 пока не оцифрованы.
+
+Словарь к упражнениям — четыре TSV-файла (глаголы / существительные / прилагательные /
+прочее) в [`src/dictionary/`](https://github.com/alexander-myltsev/buhler-sanskrit-book/tree/main/src/dictionary),
+схема `id⇥word⇥gender⇥translation⇥lesson⇥tag`, рендерится компонентом
+[`Dictionary.tsx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/components/Dictionary.tsx).
+
+## Разметка в MDX
+
+Уроки пишутся в MDX с несколькими проектными соглашениями:
+
+| Конструкция | Назначение |
+|---|---|
+| `<Sanscript text="…" from="slp1" to="devanagari"/>` | транслитерация из SLP1 в деванагари ([`Sanscript.tsx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/components/Sanscript.tsx)) |
+| `<Latin text="…"/>` | латинская транслитерация IAST курсивом ([`Latin.tsx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/components/Latin.tsx)) |
+| `<Dictionary/>` | таблицы словаря из TSV ([`Dictionary.tsx`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/components/Dictionary.tsx)) |
+| `__GT_термин__` | стилизованный грамматический термин ([`grammaticalTermShorthand`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/remark/grammaticalTermShorthand.ts)) |
+| `__GTS_slp1__` | «देवनागरी (IAST)» из SLP1 ([`grammaticalTermSanskritShorthand`](https://github.com/alexander-myltsev/buhler-sanskrit-book/blob/main/src/remark/grammaticalTermSanskritShorthand.ts)) |
+
+Транслитерация выполняется через
+[`@indic-transliteration/sanscript`](https://github.com/indic-transliteration/sanscript.js).
+
+## Сборка
+
+Требуется Node.js 18+. Зависимости зафиксированы в `package-lock.json`, поэтому команды — через npm:
 
 ```bash
-yarn
+npm install       # установить зависимости
+npm start         # локальный сервер разработки с горячей перезагрузкой
+npm run build     # собрать статический сайт в build/
+npm run serve     # локально проверить готовую сборку
 ```
 
-## Local Development
+Публикация на GitHub Pages выполняется из ветки `gh-pages` (`npm run deploy`).
 
-```bash
-yarn start
-```
+## Лицензия
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
-
-```bash
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-Using SSH:
-
-```bash
-USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```bash
-GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+Лицензия на текст и код готовится отдельно (см. открытый вопрос об атрибуции
+электронного издания). До её принятия репозиторий распространяется без явной лицензии;
+все права на электронную версию упражнений принадлежат Н. П. Лихушиной (2008), на сайт
+и разметку — сопровождающему репозитория.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -7,8 +7,8 @@ import grammaticalTermSanskritShorthand from './src/remark/grammaticalTermSanskr
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 const config: Config = {
-  title: 'My Site',
-  tagline: 'Dinosaurs are cool',
+  title: 'Санскрит: элементарный курс Бюлера — упражнения',
+  tagline: 'Электронное издание упражнений из учебника Г. Бюлера (Стокгольм, 1923)',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -34,8 +34,8 @@ const config: Config = {
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en'],
+    defaultLocale: 'ru',
+    locales: ['ru'],
   },
 
   plugins: [
@@ -74,10 +74,8 @@ const config: Config = {
         docs: {
           sidebarPath: './sidebars.ts',
           remarkPlugins: [grammaticalTermShorthand, grammaticalTermSanskritShorthand],
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/',
+            'https://github.com/alexander-myltsev/buhler-sanskrit-book/tree/main/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -103,9 +101,9 @@ const config: Config = {
       maxHeadingLevel: 4,
     },
     navbar: {
-      title: 'My Site',
+      title: 'Упражнения Бюлера',
       logo: {
-        alt: 'My Site Logo',
+        alt: 'Санскрит: элементарный курс Бюлера',
         src: 'img/logo.svg',
       },
       items: [
@@ -113,10 +111,10 @@ const config: Config = {
           type: 'docSidebar',
           sidebarId: 'tutorialSidebar',
           position: 'left',
-          label: 'Tutorial',
+          label: 'Уроки',
         },
         {
-          href: 'https://github.com/facebook/docusaurus',
+          href: 'https://github.com/alexander-myltsev/buhler-sanskrit-book',
           label: 'GitHub',
           position: 'right',
         },
@@ -126,42 +124,33 @@ const config: Config = {
       style: 'dark',
       links: [
         {
-          title: 'Docs',
+          title: 'Учебник',
           items: [
             {
-              label: 'Tutorial',
+              label: 'Введение',
               to: '/docs/intro',
             },
-          ],
-        },
-        {
-          title: 'Community',
-          items: [
             {
-              label: 'Stack Overflow',
-              href: 'https://stackoverflow.com/questions/tagged/docusaurus',
-            },
-            {
-              label: 'Discord',
-              href: 'https://discordapp.com/invite/docusaurus',
-            },
-            {
-              label: 'X',
-              href: 'https://x.com/docusaurus',
+              label: 'Урок 1',
+              to: '/docs/lesson1',
             },
           ],
         },
         {
-          title: 'More',
+          title: 'Проект',
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/facebook/docusaurus',
+              href: 'https://github.com/alexander-myltsev/buhler-sanskrit-book',
+            },
+            {
+              label: 'Issues',
+              href: 'https://github.com/alexander-myltsev/buhler-sanskrit-book/issues',
             },
           ],
         },
       ],
-      copyright: `Copyright © ${new Date().getFullYear()} My Project, Inc. Built with Docusaurus.`,
+      copyright: `Электронная версия упражнений © Н. П. Лихушина, 2008. Построено на Docusaurus.`,
     },
     prism: {
       theme: prismThemes.github,

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -11,32 +11,34 @@ type FeatureItem = {
 
 const FeatureList: FeatureItem[] = [
   {
-    title: 'Easy to Use',
+    title: 'Классический учебник',
     Svg: require('@site/static/img/undraw_docusaurus_mountain.svg').default,
     description: (
       <>
-        Docusaurus was designed from the ground up to be easily installed and
-        used to get your website up and running quickly.
+        Упражнения из «Руководства к элементарному курсу санскритского языка»
+        Г.&nbsp;Бюлера (Стокгольм, 1923) — перевод с санскрита и на санскрит
+        для каждого урока.
       </>
     ),
   },
   {
-    title: 'Focus on What Matters',
+    title: 'Электронное издание',
     Svg: require('@site/static/img/undraw_docusaurus_tree.svg').default,
     description: (
       <>
-        Docusaurus lets you focus on your docs, and we&apos;ll do the chores. Go
-        ahead and move your docs into the <code>docs</code> directory.
+        Версия&nbsp;2.0, подготовленная Н.&nbsp;П.&nbsp;Лихушиной (2008):
+        исправленные переводы, корни в ступени <em>guṇa</em> и приложенный
+        русско-санскритский словарик.
       </>
     ),
   },
   {
-    title: 'Powered by React',
+    title: 'Деванагари и IAST',
     Svg: require('@site/static/img/undraw_docusaurus_react.svg').default,
     description: (
       <>
-        Extend or customize your website layout by reusing React. Docusaurus can
-        be extended while reusing the same header and footer.
+        Санскрит показан в деванагари с латинской транслитерацией (IAST),
+        грамматические термины размечены, а по всему тексту работает поиск.
       </>
     ),
   },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -21,7 +21,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            Начать с введения →
           </Link>
         </div>
       </div>
@@ -33,8 +33,8 @@ export default function Home(): ReactNode {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title={siteConfig.title}
+      description="Электронное издание упражнений из элементарного курса санскрита Г. Бюлера (Стокгольм, 1923) — санскритско-русские и русско-санскритские упражнения с разметкой, транслитерацией и словарём.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
Hi Alexander — a first contribution toward giving the site its own identity instead of the Docusaurus template. This closes #8 (the "rename the project" issue) and lays the foundation for the exercises to read as a real edition.

## What this changes

**Kills the placeholder identity**
- `docusaurus.config.ts`: real title «Санскрит: элементарный курс Бюлера — упражнения» and tagline (were `My Site` / `Dinosaurs are cool`); `html lang` set to `ru`; navbar + footer now point at this repo instead of `facebook/docusaurus`; `editUrl` fixed to this repo so "edit this page" works; a factual edition copyright line.
- `src/pages/index.tsx`: real call-to-action button («Начать с введения →») and a real `<head>` meta description (was "Description will go into a meta tag").
- `src/components/HomepageFeatures`: three real feature cards — the source edition, Лихушина's 2008 electronic edition, Devanagari/IAST — replacing the "Easy to Use / Dinosaurs" template copy.

**Real README** — replaces the Docusaurus boilerplate with: what the project is, the source edition (Bühler 1923) and editor credit (Н. П. Лихушина, 2008), current coverage (20/48 lessons), the MDX component conventions (`<Sanscript>` / `<Latin>` / `<Dictionary>` / `__GT_` / `__GTS_`), and build instructions.

## Notes

- **`npm run build` is clean** (with `onBrokenLinks: 'throw'`, so every navbar/footer/CTA link resolves). I used npm since the committed lockfile is `package-lock.json`; the README documents that.
- **No `LICENSE` in this PR — on purpose.** The text is Лихушина's 2008 electronic edition, and we'd like to settle the attribution/licensing terms (CC-BY + editor credit) with you and samskrtam.ru before committing a license file, rather than guess. Happy to follow up in a separate PR once that's agreed.
- Scope kept deliberately narrow — one clean handshake PR. The i18n `defaultLocale` was switched `en → ru` to match the content (sets `html lang`); shout if you'd rather keep that separate.

Thanks for the work so far — glad to help push it forward.
